### PR TITLE
Remove mailing list link

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -10,9 +10,5 @@ Reference Platform Support Channels
 
 [#linaro-enterprise](https://webchat.freenode.net/) and/or [#linaro-platforms](https://webchat.freenode.net/)
 
-## Mailinglist
-[https://lists.linaro.org/mailman/listinfo/referenceplatform](https://lists.linaro.org/mailman/listinfo/referenceplatform)
-
-
 ## Bugs
 [https://bugs.linaro.org/describecomponents.cgi?product=Reference%20Platforms](https://bugs.linaro.org/describecomponents.cgi?product=Reference%20Platforms)


### PR DESCRIPTION
The mailing list has never been used: see the empty archive. Therefore, we should not advertise it and should delete the list.